### PR TITLE
Fix: favorite handler issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,9 @@ function App() {
 
   useEffect(() => {
     const movieFavourites = JSON.parse(localStorage.getItem("my-fav"));
-    setFavourits(movieFavourites);
+    if(movieFavourites) {
+      setFavourits(movieFavourites);
+    }
   }, []);
 
   const saveToLocalStorage = (items) => {
@@ -38,9 +40,8 @@ function App() {
 
   //Adding and removing favourits from the list
   const addFavouriteMovie = (movie) => {
-    const newFavouriteList = [...favourites, movie];
-    setFavourits(newFavouriteList);
-    saveToLocalStorage(newFavouriteList);
+    setFavourits(prev => [...prev,movie]);
+    saveToLocalStorage([...favourites,movie]);
   };
 
   const removeFavouriteMovie = (movie) => {

--- a/src/components/MovieList.jsx
+++ b/src/components/MovieList.jsx
@@ -5,7 +5,7 @@ const MovieList = (props) => {
   return (
     <div>
       <div className="flex items-center">
-        {props.movies.map((movie) => (
+        {props?.movies.map((movie) => (
           <div className="w-[200px]   inline-block cursor-pointer hover:scale-105 ease-in-out duration-300 mx-1">
             <img className="object-cover" src={movie.Poster} alt="poster-img" />
             <div


### PR DESCRIPTION
### Issue
Fix "Favorites not Iterable" Issue

### Description
This pull request addresses the issue #14 where the "favorites not iterable" error was occurring. The issue was due to incorrect initialization of the `favorites` state and a missing condition for handling null or undefined values.

### Changes Made
- Corrected the initialization of the `favorites` state to ensure it's always an array.
- Added a condition to handle cases where the `favorites` state is null or undefined.
- Updated the relevant parts of the code to prevent the "favorites not iterable" error.
